### PR TITLE
Fixed formating of the code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Now we support linux only
 
 ```bash
 $ curl http://meshbird.com/install.sh | sh
-````
+```
 
 or if you have Go compiler 
 


### PR DESCRIPTION
It looks good on the github, but on the site it's not ok:
![2016-01-29_09 59 20](https://cloud.githubusercontent.com/assets/234891/12669139/0d049226-c66f-11e5-8b5e-b7b401b44309.png)
